### PR TITLE
Support for Ruby 2.4.0 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
   - 2.1.0
+  - 2.4.0
 script:
   - bundle exec rspec

--- a/spec/lib/camt_parser/misc_spec.rb
+++ b/spec/lib/camt_parser/misc_spec.rb
@@ -5,7 +5,7 @@ describe CamtParser::Misc do
   let(:comma_value) { "30,12" }
 
   context '#to_amount_in_cents' do
-    specify { expect(described_class.to_amount_in_cents(dot_value)).to be_kind_of(Fixnum) }
+    specify { expect(described_class.to_amount_in_cents(dot_value)).to be_kind_of(Integer) }
     specify { expect(described_class.to_amount_in_cents(dot_value)).to eq(3012) }
     specify { expect(described_class.to_amount_in_cents(comma_value)).to eq(3012) }
   end


### PR DESCRIPTION
Fixnum has been deprecated with Ruby 2.4.0. Fixnum has therefore changed to Integer to succeed in the CI tests while it represents the same as Fixnum. (Rationale: http://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html)