### PR TITLE
Add creditor reference in transaction object

### DIFF
--- a/lib/camt_parser/general/transaction.rb
+++ b/lib/camt_parser/general/transaction.rb
@@ -85,6 +85,10 @@ module CamtParser
       @mandate_reference ||= @xml_data.xpath('Refs/MndtId/text()').text
     end
 
+    def creditor_reference # May be missing
+      @creditor_reference ||= @xml_data.xpath('RmtInf/Strd/CdtrRefInf/Ref/text()').text
+    end
+
     def transaction_id # May be missing
       @transaction_id ||= @xml_data.xpath('Refs/TxId/text()').text
     end

--- a/spec/fixtures/053/valid_example_v4.xml
+++ b/spec/fixtures/053/valid_example_v4.xml
@@ -351,7 +351,7 @@
                       <Prtry>ISR Reference</Prtry>
                     </CdOrPrtry>
                   </Tp>
-                  <Ref>000000000002015110002913192</Ref>
+                  <Ref>CreditorReference</Ref>
                 </CdtrRefInf>
                 <AddtlRmtInf>?REJECT?0</AddtlRmtInf>
               </Strd>

--- a/spec/lib/camt_parser/general/transaction_spec.rb
+++ b/spec/lib/camt_parser/general/transaction_spec.rb
@@ -54,5 +54,7 @@ describe CamtParser::Transaction do
       specify { expect(ex_transaction.amount).to eq(BigDecimal.new('100')) }
       specify { expect(ex_transaction.amount_in_cents).to eq(10000) }
     end
+
+    specify { expect(ex_transaction.creditor_reference).to eq("CreditorReference") }
   end
 end


### PR DESCRIPTION
By this PR, I want to add a `creditor_reference` on transaction object. It's used by PostFinance in Switzerland to get the Reference of the BVR used.