### PR TITLE
Return nil for missing amounts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    camt_parser (2.6.0)
+    camt_parser (2.6.1)
       nokogiri
 
 GEM

--- a/lib/camt_parser/misc.rb
+++ b/lib/camt_parser/misc.rb
@@ -2,11 +2,15 @@ module CamtParser
   class Misc
     class << self
       def to_amount_in_cents(value)
+        return nil if value == nil || value.strip == ''
+
         value.gsub(/[,|\.](\d*)/) { $1.ljust(2, '0') }.to_i
       end
 
       def to_amount(value)
-        BigDecimal value.gsub(',', '.')
+        return nil if value == nil || value.strip == ''
+
+        BigDecimal(value.gsub(',', '.'))
       end
     end
   end

--- a/lib/camt_parser/version.rb
+++ b/lib/camt_parser/version.rb
@@ -1,3 +1,3 @@
 module CamtParser
-  VERSION = "2.6.0"
+  VERSION = "2.6.1"
 end

--- a/spec/lib/camt_parser/misc_spec.rb
+++ b/spec/lib/camt_parser/misc_spec.rb
@@ -8,11 +8,15 @@ describe CamtParser::Misc do
     specify { expect(described_class.to_amount_in_cents(dot_value)).to be_kind_of(Integer) }
     specify { expect(described_class.to_amount_in_cents(dot_value)).to eq(3012) }
     specify { expect(described_class.to_amount_in_cents(comma_value)).to eq(3012) }
+    specify { expect(described_class.to_amount_in_cents('')).to eq(nil) }
+    specify { expect(described_class.to_amount_in_cents(nil)).to eq(nil) }
   end
 
   context '#to_amount' do
     specify { expect(described_class.to_amount(dot_value)).to be_kind_of(BigDecimal) }
     specify { expect(described_class.to_amount(dot_value)).to eq(30.12) }
     specify { expect(described_class.to_amount(comma_value)).to eq(30.12) }
+    specify { expect(described_class.to_amount('')).to eq(nil) }
+    specify { expect(described_class.to_amount(nil)).to eq(nil) }
   end
 end


### PR DESCRIPTION
When no value is given for an amount field, we do not want to fail with
an exception, as it is perfectly valid in camt files.
Instead we want to return nil to make it clear that there is noving
to convert into an integer or bigdecimal.
That also prevents hiding that the value is missing, as would be the
case in case of converting to 0/0.0
We cannot make an assumption about whether one needs to differentiate it
however, checking for nil is possible and default to 0.
If we already default to 0, that becomes impossible.

Refs #21