### PR TITLE
Support currency and from/to dates in report

### DIFF
--- a/lib/camt_parser/052/report.rb
+++ b/lib/camt_parser/052/report.rb
@@ -25,6 +25,14 @@ module CamtParser
         @legal_sequence_number ||= @xml_data.xpath('LglSeqNb/text()').text
       end
 
+      def from_date_time
+        @from_date_time ||= (x = @xml_data.xpath('FrToDt/FrDtTm')).empty? ? nil : Time.parse(x.first.content)
+      end
+
+      def to_date_time
+        @to_date_time ||= (x = @xml_data.xpath('FrToDt/ToDtTm')).empty? ? nil : Time.parse(x.first.content)
+      end
+
       def opening_balance
         @opening_balance ||= begin
           bal = @xml_data.xpath('Bal/Tp//Cd[contains(text(), "PRCD")]').first.ancestors('Bal')

--- a/lib/camt_parser/general/account.rb
+++ b/lib/camt_parser/general/account.rb
@@ -15,5 +15,9 @@ module CamtParser
     def bank_name
       @bank_name ||= @xml_data.xpath('Svcr/FinInstnId/Nm/text()').text
     end
+
+    def currency
+      @currency ||= @xml_data.xpath('Ccy/text()').text
+    end
   end
 end

--- a/spec/fixtures/052/valid_example_with_dates.xml
+++ b/spec/fixtures/052/valid_example_with_dates.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Document xmlns="urn:iso:std:iso:20022:tech:xsd:camt.052.001.02">
+  <BkToCstmrAcctRpt>
+    <GrpHdr>
+      <MsgId>camt.052-2019-08-09-11-17-11</MsgId>
+      <CreDtTm>2019-08-09T11:17:11:735</CreDtTm>
+      <MsgRcpt>
+        <Nm>Test User</Nm>
+        <PstlAdr>
+          <StrtNm>Test street</StrtNm>
+          <BldgNb>1</BldgNb>
+          <TwnNm>Test town</TwnNm>
+          <PstCd>11111</PstCd>
+          <Ctry>GB</Ctry>
+        </PstlAdr>
+      </MsgRcpt>
+    </GrpHdr>
+    <Rpt>
+      <Id>1234567890-2019-08-09-11-17-11</Id>
+      <CreDtTm>2019-08-09T11:17:11:735</CreDtTm>
+      <FrToDt>
+        <FrDtTm>2013-01-01T00:00:00:000</FrDtTm>
+        <ToDtTm>2019-08-09T00:00:00:000</ToDtTm>
+      </FrToDt>
+      <Acct>
+        <Id>
+          <Othr>
+            <Id>0000000000000001</Id>
+          </Othr>
+        </Id>
+        <Ccy>EUR</Ccy>
+        <Svcr>
+          <FinInstnId>
+            <BICFI>TESTBKGB</BICFI>
+            <Nm>Test bank</Nm>
+            <Othr>
+              <Id>1234</Id>
+            </Othr>
+          </FinInstnId>
+        </Svcr>
+      </Acct>
+      <Ntry>
+        <Amt Ccy="EUR">5.00</Amt>
+        <CdtDbtInd>DBIT</CdtDbtInd>
+        <Sts>BOOK</Sts>
+        <ValDt>
+          <Dt>2019-07-19</Dt>
+        </ValDt>
+        <BkTxCd>
+          <Prtry>
+            <Cd>00000000000</Cd>
+            <Issr>Test Banking Association</Issr>
+          </Prtry>
+        </BkTxCd>
+        <NtryDtls>
+          <TxDtls>
+            <Refs>
+              <AcctSvcrRef>0000000AA000000</AcctSvcrRef>
+            </Refs>
+            <Amt Ccy="EUR">5.00</Amt>
+            <CdtDbtInd>DBIT</CdtDbtInd>
+            <RltdPties>
+              <CdtrAcct>
+                <Id>
+                  <Othr>
+                    <Id>0000000000000000</Id>
+                  </Othr>
+                </Id>
+                <Nm>CARD TRANSACTIONS EUR</Nm>
+              </CdtrAcct>
+              <Cdtr>
+                <Nm>PAYPAL - TEST/000000</Nm>
+                <PstlAdr>
+                  <Ctry>LUX</Ctry>
+                </PstlAdr>
+              </Cdtr>
+            </RltdPties>
+            <RltdAgts>
+              <CdtrAgt>
+                <FinInstnId>
+                  <Othr>
+                    <Id>1234</Id>
+                  </Othr>
+                </FinInstnId>
+              </CdtrAgt>
+            </RltdAgts>
+            <RmtInf>
+            </RmtInf>
+          </TxDtls>
+        </NtryDtls>
+      </Ntry>
+    </Rpt>
+  </BkToCstmrAcctRpt>
+</Document>

--- a/spec/lib/camt_parser/052/report_spec.rb
+++ b/spec/lib/camt_parser/052/report_spec.rb
@@ -15,4 +15,17 @@ describe CamtParser::Format052::Report do
   specify { expect(ex_rpt.closing_balance).to be_kind_of(CamtParser::AccountBalance) }
 
   specify { expect(ex_rpt.identification).to eq("0352C5220131227110203") }
+
+  specify { expect(ex_rpt.from_date_time).to be_nil }
+  specify { expect(ex_rpt.to_date_time).to be_nil }
+
+  context 'Rpt/FrToDt' do
+    let(:camt) { CamtParser::File.parse('spec/fixtures/052/valid_example_with_dates.xml') }
+
+    specify { expect(ex_rpt.from_date_time).to be_kind_of(Time) }
+    specify { expect(ex_rpt.from_date_time).to eq(Time.new(2013, 1, 1, 0, 0, 0)) }
+
+    specify { expect(ex_rpt.to_date_time).to be_kind_of(Time) }
+    specify { expect(ex_rpt.to_date_time).to eq(Time.new(2019, 8, 9, 0, 0, 0)) }
+  end
 end

--- a/spec/lib/camt_parser/general/account_spec.rb
+++ b/spec/lib/camt_parser/general/account_spec.rb
@@ -9,5 +9,6 @@ describe CamtParser::Account do
   specify { expect(account.iban).to eq("DE14740618130000033626") }
   specify { expect(account.bic).to eq("GENODEF1PFK") }
   specify { expect(account.bank_name).to eq("VR-Bank Rottal-Inn eG") }
+  specify { expect(account.currency).to eq("EUR") }
 end
 


### PR DESCRIPTION
Adds support for the following camt.052 Report elements:

- Report account currency (`Rpt/Acct/Ccy`)
- Report from/to date times (`Rpt/FrToDt/FrDtTm` and `Rpt/FrToDt/ToDtTm`)