### PR TITLE
Adds #reason_code accessor to transaction.

### DIFF
--- a/lib/camt_parser/general/transaction.rb
+++ b/lib/camt_parser/general/transaction.rb
@@ -105,6 +105,10 @@ module CamtParser
       @addition_information ||= @xml_data.xpath('AddtlTxInf/text()').text
     end
 
+    def reason_code # May be missing
+      @reason_code ||= @xml_data.xpath('RtrInf/Rsn/Cd/text()').text
+    end
+
     private
 
     def parse_amount

--- a/spec/lib/camt_parser/general/transaction_spec.rb
+++ b/spec/lib/camt_parser/general/transaction_spec.rb
@@ -73,6 +73,12 @@ describe CamtParser::Transaction do
       specify { expect(ex_transaction.amount_in_cents).to eq(10000) }
     end
 
+    context '#reason_code' do
+      let(:ex_entry) { entries[12] }
+
+      specify { expect(ex_transaction.reason_code).to eq("MD06") }
+    end
+
     specify { expect(ex_transaction.creditor_reference).to eq("CreditorReference") }
   end
 end


### PR DESCRIPTION
Identifying reason code is useful to provide translated description of information about returns/declines/chargebacks etc... Currently, we have Additional Information per `Entry` which is not sufficient and usually lacks full descriptions.

Read more: https://www.hettwer-beratung.de/sepa-spezialwissen/sepa-reason-codes/