### PR TITLE
adds msg id accessor to batch detail

### DIFF
--- a/lib/camt_parser/general/batch_detail.rb
+++ b/lib/camt_parser/general/batch_detail.rb
@@ -8,6 +8,10 @@ module CamtParser
       @payment_information_identification ||= @xml_data.xpath('PmtInfId/text()').text
     end
 
+    def msg_id # may be missing
+      @msg_id ||= @xml_data.xpath('MsgId/text()').text
+    end
+
     def number_of_transactions
       @number_of_transactions ||= @xml_data.xpath('NbOfTxs/text()').text
     end

--- a/spec/fixtures/053/valid_example_with_batch.xml
+++ b/spec/fixtures/053/valid_example_with_batch.xml
@@ -140,6 +140,7 @@
         <NtryDtls>
           <Btch>
             <PmtInfId>O0OpeAYTkhjerKu3eE9asw</PmtInfId>
+            <MsgId>02453b1e-7c11-4107-a777-ad9c273b4149</MsgId>
             <NbOfTxs>3</NbOfTxs>
           </Btch>
         </NtryDtls>

--- a/spec/lib/camt_parser/general/batch_detail_spec.rb
+++ b/spec/lib/camt_parser/general/batch_detail_spec.rb
@@ -10,4 +10,5 @@ describe CamtParser::BatchDetail do
   
   specify { expect(batch_detail.payment_information_identification).to eq("O0OpeAYTkhjerKu3eE9asw") }
   specify { expect(batch_detail.number_of_transactions).to eq("3") }
+  specify { expect(batch_detail.msg_id).to eq('02453b1e-7c11-4107-a777-ad9c273b4149') }
 end


### PR DESCRIPTION
It would be great to add `MsgId` accessor for batch detail as some back office and ERP systems can also make use of it to bulk update transaction statuses.

https://github.com/Barzahlen/camt_parser/issues/35

